### PR TITLE
use manufacturer from configuration for serial numbers

### DIFF
--- a/netbox_cisco_support/management/commands/sync_eox_data.py
+++ b/netbox_cisco_support/management/commands/sync_eox_data.py
@@ -317,7 +317,7 @@ class Command(BaseCommand):
             i += 1
 
         # Step 2: Get all Serial Numbers for all Devices of that particular manufacturer
-        serial_numbers = self.get_serial_numbers(kwargs['manufacturer'])
+        serial_numbers = self.get_serial_numbers(MANUFACTURER)
         self.stdout.write(self.style.SUCCESS('Gathering data for these Serial Numbers: ' + ', '.join(serial_numbers)))
 
         i = 1


### PR DESCRIPTION
Setting `manufacturer` in `configuration.py` works for gathering by PID, but not by SN.

This small change fixes that.